### PR TITLE
Lifespan.End update after provisioning finished

### DIFF
--- a/api.rest
+++ b/api.rest
@@ -12,23 +12,37 @@ GET {{baseUrl}}/health
 GET {{baseUrl}}/catalogItems
 
 ### Get CatalogItem by ID
-GET {{baseUrl}}/catalogItems/sandboxes-gpte.ocp4-dil-streaming-wksp.dev
+GET {{baseUrl}}/catalogItems/tests.babylon-empty-config.prod
 
 ### Start Provision
-POST {{baseUrl}}/provision
+POST {{baseUrl}}/serviceRequest
 Content-Type: application/json
 Accept: application/json
 
 {
-    "Name": "test-auto-20.babylon-empty-config.prod",
+    "Name": "test-auto-10.babylon-empty-config.prod",
     "ProviderName": "tests.babylon-empty-config.prod",
     "Purpose": "Testing",
-    "Start": "2023-08-15T01:23:45Z",
-    "Stop": "2023-08-16T01:23:45Z"
+    "Start": "2023-12-05T01:23:45Z",
+    "Stop": "2023-12-06T01:23:45Z"
 }
 
-### Get Provision status
-GET {{baseUrl}}/provision/test-auto-20.babylon-empty-config.prod
+### Get Provision information
+GET {{baseUrl}}/serviceRequest/test-auto-10.babylon-empty-config.prod
 
 ### Delete Provision
-DELETE {{baseUrl}}/provision/test-auto-20.babylon-empty-config.prod
+DELETE {{baseUrl}}/serviceRequest/test-auto-10.babylon-empty-config.prod
+
+### Get ratings
+GET {{baseUrl}}/ratings/tests.babylon-empty-config.prod
+
+### Create rating
+POST {{baseUrl}}/ratings
+Content-Type: application/json
+Accept: application/json
+
+{
+    "ProvisionName": "test-auto-10.babylon-empty-config.prod",
+    "Email":"kmalgich@redhat.com",
+    "Rating":40
+}

--- a/api.rest
+++ b/api.rest
@@ -23,8 +23,8 @@ Accept: application/json
     "Name": "test-auto-10.babylon-empty-config.prod",
     "ProviderName": "tests.babylon-empty-config.prod",
     "Purpose": "Testing",
-    "Start": "2023-12-05T01:23:45Z",
-    "Stop": "2023-12-06T01:23:45Z"
+    "Start": "2023-12-06T01:00:00Z",
+    "Stop": "2023-12-07T01:00:00Z"
 }
 
 ### Get Provision information

--- a/api.rest
+++ b/api.rest
@@ -3,7 +3,7 @@
 # To use it, install the extension and then open this file in VS Code.
 # You can then send the requests by clicking the "Send Request" link above each request.
 
-@baseUrl = http://localhost:8080
+@baseUrl = http://127.0.0.1:20001
 
 ### Get Health
 GET {{baseUrl}}/health

--- a/cmd/kube/apiextensions/v1/types.go
+++ b/cmd/kube/apiextensions/v1/types.go
@@ -9,7 +9,7 @@ import (
 // -----------------------------------------------------------------------------
 type CatalogItemLifespan struct {
 	Default         string `json:"default"`
-	Maximus         string `json:"maximum"`
+	Maximum         string `json:"maximum"`
 	RelativeMaximum string `json:"relativeMaximum"`
 }
 
@@ -49,7 +49,7 @@ type ResourceClaimProvider struct {
 }
 
 type ResourceClaimProvisionData struct {
-	GUID   string `json:"guid"`
+	GUID   string `json:"GUID"`
 	LabURL string `json:"lab_ui_url"`
 }
 
@@ -61,7 +61,8 @@ type ResourceClaimStatusSummary struct {
 }
 
 type ResourceClaimStatusLifespan struct {
-	End string `json:"end"`
+	End   string `json:"end"`
+	Start string `json:"start"`
 }
 
 type ResourceClaimSpecLifespan struct {
@@ -70,14 +71,14 @@ type ResourceClaimSpecLifespan struct {
 
 // +k8s:deepcopy-gen=true
 type ResourceClaimStatus struct {
-	Summary   ResourceClaimStatusSummary  `json:"summary"`
-	Lifespan  ResourceClaimStatusLifespan `json:"lifespan"`
+	Summary  ResourceClaimStatusSummary  `json:"summary"`
+	Lifespan ResourceClaimStatusLifespan `json:"lifespan"`
 }
 
 // +k8s:deepcopy-gen=true
 type ResourceClaimSpec struct {
 	Lifespan *ResourceClaimSpecLifespan `json:"lifespan,omitempty"`
-	Provider ResourceClaimProvider     `json:"provider"`
+	Provider ResourceClaimProvider      `json:"provider"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/cmd/models/catalog_items.go
+++ b/cmd/models/catalog_items.go
@@ -58,15 +58,15 @@ func (c *CatalogItemsController) ListAll() []CatalogItemInfo {
 	r := make([]CatalogItemInfo, 0, len(items))
 	for _, item := range items {
 		catalogItem := item.(*v1.CatalogItem)
-		anotations := catalogItem.ObjectMeta.Annotations
+		annotations := catalogItem.ObjectMeta.Annotations
 		labels := catalogItem.ObjectMeta.Labels
 
 		r = append(r, CatalogItemInfo{
 			Name:              catalogItem.ObjectMeta.Name,
 			NameSpace:         catalogItem.ObjectMeta.Namespace,
-			DisplayName:       anotations["babylon.gpte.redhat.com/displayName"],
-			Description:       anotations["babylon.gpte.redhat.com/description"],
-			DescriptionFormat: anotations["babylon.gpte.redhat.com/descriptionFormat"],
+			DisplayName:       annotations["babylon.gpte.redhat.com/displayName"],
+			Description:       annotations["babylon.gpte.redhat.com/description"],
+			DescriptionFormat: annotations["babylon.gpte.redhat.com/descriptionFormat"],
 			AssetUUID:         labels["gpte.redhat.com/asset-uuid"],
 			Provider:          labels["babylon.gpte.redhat.com/Provider"],
 		})
@@ -84,7 +84,7 @@ func (c *CatalogItemsController) findKey(name string) string {
 	for _, key := range keys {
 		strSlice := strings.Split(key, "/")
 		providerName := strSlice[len(strSlice)-1]
-		if 0 == strings.Compare(strings.ToLower(providerName), strings.ToLower(name)) {
+		if strings.Compare(strings.ToLower(providerName), strings.ToLower(name)) == 0 {
 			return key
 		}
 	}

--- a/cmd/models/catalog_items.go
+++ b/cmd/models/catalog_items.go
@@ -27,9 +27,9 @@ type CatalogItemInfo struct {
 	DescriptionFormat       string
 	AssetUUID               string
 	Provider                string
-	DefaultLifespan         string
-	MaximumLifespan         string
-	RelativeMaximumLifespan string
+	defaultLifespan         string
+	maximumLifespan         string
+	relativeMaximumLifespan string
 }
 
 func NewCatalogItemsController(
@@ -109,9 +109,9 @@ func (c *CatalogItemsController) GetByName(name string) (*CatalogItemInfo, bool,
 		DescriptionFormat:       item.(*v1.CatalogItem).ObjectMeta.Annotations["babylon.gpte.redhat.com/descriptionFormat"],
 		AssetUUID:               item.(*v1.CatalogItem).ObjectMeta.Labels["gpte.redhat.com/asset-uuid"],
 		Provider:                item.(*v1.CatalogItem).ObjectMeta.Labels["babylon.gpte.redhat.com/Provider"],
-		DefaultLifespan:         item.(*v1.CatalogItem).Spec.Lifespan.Default,
-		MaximumLifespan:         item.(*v1.CatalogItem).Spec.Lifespan.Maximum,
-		RelativeMaximumLifespan: item.(*v1.CatalogItem).Spec.Lifespan.RelativeMaximum,
+		defaultLifespan:         item.(*v1.CatalogItem).Spec.Lifespan.Default,
+		maximumLifespan:         item.(*v1.CatalogItem).Spec.Lifespan.Maximum,
+		relativeMaximumLifespan: item.(*v1.CatalogItem).Spec.Lifespan.RelativeMaximum,
 	}, true, nil
 }
 
@@ -144,7 +144,7 @@ func (c *CatalogItemsController) GetDefaultLifespan(name string) (time.Duration,
 		return 0, fmt.Errorf("catalog item \"%s\" not found", name)
 	}
 
-	return lifespanToDuration(catalogItem.DefaultLifespan)
+	return lifespanToDuration(catalogItem.defaultLifespan)
 }
 
 func (c *CatalogItemsController) GetMaximumLifespan(name string) (time.Duration, error) {
@@ -157,7 +157,7 @@ func (c *CatalogItemsController) GetMaximumLifespan(name string) (time.Duration,
 		return 0, fmt.Errorf("catalog item \"%s\" not found", name)
 	}
 
-	return lifespanToDuration(catalogItem.MaximumLifespan)
+	return lifespanToDuration(catalogItem.maximumLifespan)
 }
 
 func (c *CatalogItemsController) GetRelativeMaximumLifespan(name string) (time.Duration, error) {
@@ -170,5 +170,5 @@ func (c *CatalogItemsController) GetRelativeMaximumLifespan(name string) (time.D
 		return 0, fmt.Errorf("catalog item \"%s\" not found", name)
 	}
 
-	return lifespanToDuration(catalogItem.RelativeMaximumLifespan)
+	return lifespanToDuration(catalogItem.relativeMaximumLifespan)
 }

--- a/cmd/models/resource_claims.go
+++ b/cmd/models/resource_claims.go
@@ -149,6 +149,27 @@ func (c *ResourceClaimsController) GetResourceClaimDetails(
 	}, ok, nil
 }
 
+func (c *ResourceClaimsController) UpdateLifespanEnd(name, lifespanEnd string) error {
+	item, ok, err := c.store.GetByKey(fmt.Sprintf("%s/%s", c.namespace, name))
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return fmt.Errorf("%s not found", name)
+	}
+
+	rc := item.(*v1.ResourceClaim)
+	rc.Spec.Lifespan.End = lifespanEnd
+
+	_, err = c.clientSet.ResourceClaims(c.namespace).Update(rc)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *ResourceClaimsController) GetUID(name string) (*string, error) {
 	item, ok, err := c.store.GetByKey(fmt.Sprintf("%s/%s", c.namespace, name))
 	if err != nil {

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -17,9 +17,9 @@ type: application
 # This is the chart version. This version number should be incremented each
 # time you make changes to the chart and its templates, including the app
 # version.
-version: 0.4.0
+version: 0.5.0
 
 # This is the version number of the application being deployed. This
 # version number should be incremented each time you make changes to
 # the application.
-appVersion: 0.5.0
+appVersion: 0.6.0

--- a/helm/templates/role.yaml
+++ b/helm/templates/role.yaml
@@ -18,4 +18,5 @@ rules:
   - watch
   - create
   - delete
+  - update
 {{- end }}

--- a/odo-rbac.yaml
+++ b/odo-rbac.yaml
@@ -23,6 +23,7 @@ rules:
   - watch
   - create
   - delete
+  - update
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Provisioning may require significant time, which should not be included in the lifespan calculation. Therefore, the lifespan.end date should be updated to begin from the timestamp when provisioning changes to 'started' status.